### PR TITLE
Add pytest to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,3 +33,25 @@ jobs:
         with:
           options: "--check --verbose"
           src: "."
+
+  # Instead of in "lint.yml" the whole file could be renamed
+  # as "pre-build.yml" or something. But the point of this repo
+  # is to emphasize pre-commit and linting, not unit testing.
+  pytest:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run pytest on root dir
+        run: pytest -v .

--- a/converter.py
+++ b/converter.py
@@ -29,7 +29,7 @@ large_sum_words = [
 ]
 
 
-def converter(n):
+def convert(n):
     word = []
     blankword = ""
 
@@ -124,6 +124,6 @@ if __name__ == "__main__":
             if n == "exit":
                 break
             int(n)
-            print(n, "-->", converter(n))
+            print(n, "-->", convert(n))
         except ValueError:
             print("Error: Invalid Number!")

--- a/converter_test.py
+++ b/converter_test.py
@@ -1,0 +1,6 @@
+import converter
+
+def test_convert():
+    assert converter.convert("1") == "One"
+    assert converter.convert("-45") == "(negative) Forty five"
+    assert converter.convert("2016") == "Two thousand and sixteen"

--- a/converter_test.py
+++ b/converter_test.py
@@ -1,5 +1,6 @@
 import converter
 
+
 def test_convert():
     assert converter.convert("1") == "One"
     assert converter.convert("-45") == "(negative) Forty five"


### PR DESCRIPTION
This is NOT textbook pytest. If that were the focus, you should use `src/` and `tests/` as specified here [Pytest: Tests outside application code](https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#tests-outside-application-code).

But this requires a lot of extra overhead with init and project files that would be distracting.